### PR TITLE
Switch to Node.js client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+session_token.tmp
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "wisenet-wave-api-example",
+  "version": "1.0.0",
+  "scripts": {
+    "start": "node wisenet_wave_main.js"
+  },
+  "dependencies": {
+    "axios": "^1.6.7"
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,32 @@
-This is a test!
+# Wisenet Wave API Example
+
+Dieses Repository enthaelt mehrere Node.js-Skripte, die die REST API von Wisenet Wave nutzen. Es werden keine Python-Abhaengigkeiten mehr benoetigt. Der Session-Token wird temporaer in `session_token.tmp` gespeichert und nach dem Logout wieder geloescht.
+
+## Voraussetzungen
+
+- Node.js
+- Abhaengigkeit `axios` (wird ueber `npm install` installiert)
+
+## Installation
+
+```bash
+npm install
+```
+
+## Nutzung
+
+Einzelschritte:
+
+```bash
+node wisenet_wave_createsession.js --base-url https://<SERVER> --username <USER> --password <PASS>
+node wisenet_wave_systeminfo.js --base-url https://<SERVER>
+node wisenet_wave_deletesession.js --base-url https://<SERVER>
+```
+
+Alle Schritte in einem Durchlauf:
+
+```bash
+node wisenet_wave_main.js --base-url https://<SERVER> --username <USER> --password <PASS>
+```
+
+Optional kann `--insecure` angegeben werden, um die Zertifikatspruefung zu deaktivieren.

--- a/wisenet_wave_createsession.js
+++ b/wisenet_wave_createsession.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const https = require('https');
+const axios = require('axios');
+
+const TOKEN_FILE = 'session_token.tmp';
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const cfg = { insecure: false };
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--insecure') {
+      cfg.insecure = true;
+    } else if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      const value = args[++i];
+      cfg[key] = value;
+    }
+  }
+  return cfg;
+}
+
+function getAgent(insecure) {
+  return new https.Agent({ rejectUnauthorized: !insecure });
+}
+
+async function createSession(baseUrl, username, password, insecure) {
+  const response = await axios.post(
+    `${baseUrl.replace(/\/$/, '')}/api/login`,
+    { username, password },
+    { httpsAgent: getAgent(insecure) }
+  );
+  const data = response.data;
+  const token = data.sessionId || data.token;
+  if (token) {
+    fs.writeFileSync(TOKEN_FILE, token);
+  }
+  return token;
+}
+
+if (require.main === module) {
+  const cfg = parseArgs();
+  const { baseUrl, username, password, insecure } = cfg;
+  if (!baseUrl || !username || !password) {
+    console.error('Usage: node wisenet_wave_createsession.js --base-url <URL> --username <USER> --password <PASS> [--insecure]');
+    process.exit(1);
+  }
+  createSession(baseUrl, username, password, insecure)
+    .then(token => {
+      console.log('Token:', token);
+    })
+    .catch(err => {
+      console.error(err);
+      process.exit(1);
+    });
+}
+
+module.exports = { createSession, TOKEN_FILE };

--- a/wisenet_wave_deletesession.js
+++ b/wisenet_wave_deletesession.js
@@ -1,0 +1,62 @@
+const fs = require('fs');
+const https = require('https');
+const axios = require('axios');
+const { TOKEN_FILE } = require('./wisenet_wave_createsession');
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const cfg = { insecure: false };
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--insecure') {
+      cfg.insecure = true;
+    } else if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      const value = args[++i];
+      cfg[key] = value;
+    }
+  }
+  return cfg;
+}
+
+function getAgent(insecure) {
+  return new https.Agent({ rejectUnauthorized: !insecure });
+}
+
+async function deleteSession(baseUrl, token, insecure) {
+  await axios.post(
+    `${baseUrl.replace(/\/$/, '')}/api/logout`,
+    null,
+    {
+      httpsAgent: getAgent(insecure),
+      headers: { Cookie: `session=${token}` }
+    }
+  );
+  if (fs.existsSync(TOKEN_FILE)) {
+    fs.unlinkSync(TOKEN_FILE);
+  }
+}
+
+if (require.main === module) {
+  const cfg = parseArgs();
+  const { baseUrl, insecure } = cfg;
+  if (!baseUrl) {
+    console.error('Usage: node wisenet_wave_deletesession.js --base-url <URL> [--insecure]');
+    process.exit(1);
+  }
+  if (!fs.existsSync(TOKEN_FILE)) {
+    console.error('Token file not found. Nothing to delete.');
+    process.exit(1);
+  }
+  const token = fs.readFileSync(TOKEN_FILE, 'utf8').trim();
+  deleteSession(baseUrl, token, insecure)
+    .then(() => {
+      console.log('Session closed');
+    })
+    .catch(err => {
+      console.error(err);
+      process.exit(1);
+    });
+}
+
+module.exports = { deleteSession };

--- a/wisenet_wave_main.js
+++ b/wisenet_wave_main.js
@@ -1,0 +1,48 @@
+const { createSession } = require('./wisenet_wave_createsession');
+const { systemInformation } = require('./wisenet_wave_systeminfo');
+const { deleteSession } = require('./wisenet_wave_deletesession');
+const fs = require('fs');
+const { TOKEN_FILE } = require('./wisenet_wave_createsession');
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const cfg = { insecure: false };
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--insecure') {
+      cfg.insecure = true;
+    } else if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      const value = args[++i];
+      cfg[key] = value;
+    }
+  }
+  return cfg;
+}
+
+async function main() {
+  const cfg = parseArgs();
+  const { baseUrl, username, password, insecure } = cfg;
+  if (!baseUrl || !username || !password) {
+    console.error('Usage: node wisenet_wave_main.js --base-url <URL> --username <USER> --password <PASS> [--insecure]');
+    process.exit(1);
+  }
+
+  const token = await createSession(baseUrl, username, password, insecure);
+  console.log('Session token:', token);
+
+  const info = await systemInformation(baseUrl, token, insecure);
+  console.log('System information:', JSON.stringify(info, null, 2));
+
+  await deleteSession(baseUrl, token, insecure);
+  if (!fs.existsSync(TOKEN_FILE)) {
+    console.log('Session closed');
+  }
+}
+
+if (require.main === module) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/wisenet_wave_systeminfo.js
+++ b/wisenet_wave_systeminfo.js
@@ -1,0 +1,59 @@
+const fs = require('fs');
+const https = require('https');
+const axios = require('axios');
+const { TOKEN_FILE } = require('./wisenet_wave_createsession');
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const cfg = { insecure: false };
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--insecure') {
+      cfg.insecure = true;
+    } else if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      const value = args[++i];
+      cfg[key] = value;
+    }
+  }
+  return cfg;
+}
+
+function getAgent(insecure) {
+  return new https.Agent({ rejectUnauthorized: !insecure });
+}
+
+async function systemInformation(baseUrl, token, insecure) {
+  const response = await axios.get(
+    `${baseUrl.replace(/\/$/, '')}/api/system/info`,
+    {
+      httpsAgent: getAgent(insecure),
+      headers: { Cookie: `session=${token}` }
+    }
+  );
+  return response.data;
+}
+
+if (require.main === module) {
+  const cfg = parseArgs();
+  const { baseUrl, insecure } = cfg;
+  if (!baseUrl) {
+    console.error('Usage: node wisenet_wave_systeminfo.js --base-url <URL> [--insecure]');
+    process.exit(1);
+  }
+  if (!fs.existsSync(TOKEN_FILE)) {
+    console.error('Token file not found. Please create a session first.');
+    process.exit(1);
+  }
+  const token = fs.readFileSync(TOKEN_FILE, 'utf8').trim();
+  systemInformation(baseUrl, token, insecure)
+    .then(info => {
+      console.log('System information:', JSON.stringify(info, null, 2));
+    })
+    .catch(err => {
+      console.error(err);
+      process.exit(1);
+    });
+}
+
+module.exports = { systemInformation };


### PR DESCRIPTION
## Summary
- remove obsolete Python requirements
- clarify in README that only Node.js is needed

## Testing
- `node --check wisenet_wave_createsession.js`
- `node --check wisenet_wave_systeminfo.js`
- `node --check wisenet_wave_deletesession.js`
- `node --check wisenet_wave_main.js`
- `npm install`


------
https://chatgpt.com/codex/tasks/task_b_684175830eec8324adb86f0934c4c43d